### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: javalon2
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/MrFasolo97/javalon2/security/code-scanning/1](https://github.com/MrFasolo97/javalon2/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. The best practice is to set this at the top level (applies to all jobs), unless individual jobs require different permissions. For npm publishing, the workflow typically only needs `contents: read` (to check out code) and possibly `packages: write` (if publishing to GitHub Packages), but since this workflow publishes to npmjs.org, not GitHub Packages, `contents: read` is likely sufficient. If any job needs more, it can be overridden at the job level. The fix is to add the following at the top level, just after the `name` field:

```yaml
permissions:
  contents: read
```

This should be inserted after line 4.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
